### PR TITLE
Support mult-goal bodied defrels, test for proper suspend/interleave

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -8,6 +8,7 @@
    "core.rkt"
    [conj conj2]
    [fresh fresh1]
+   [defrel defrel-core]
    [run run-core]
    [run* run*-core]
    [quote quote-core])
@@ -33,7 +34,18 @@
   (all-from-out "core.rkt")
   conj2 fresh1 run-core run*-core quote-core)
  (for-space mk conj fresh conde quote quasiquote list)
- run run* unquote)
+ defrel run run* unquote)
+
+(define-syntax defrel
+  (syntax-parser
+    [(~describe
+      "(defrel (<name> <id> ...+) <goal> ...+)"
+      (_ h:define-header/c g:goal/c))
+     #'(defrel-core h g)]
+    [(~describe
+      "(defrel (<name> <id> ...+) <goal> ...+)"
+      (_ h:define-header/c g+:goal/c ...+))
+     #'(defrel-core h (fresh () g+ ...))]))
 
 (define-syntax run
   (syntax-parser

--- a/tests/test2.rkt
+++ b/tests/test2.rkt
@@ -11,9 +11,20 @@
         (== `(,head . ,result) l3)
         (appendo rest l2 result)))]))
 
+(defrel (rel/1-goal-body x)
+  (== x 'cat))
+
+(defrel (rel/2-goal-body x y)
+  (== x 'fish)
+  (== y 'horse))
+
+(defrel (nevero x)
+  (nevero x))
+
 (module+ test
   (require
-    rackunit)
+    rackunit
+	racket/engine)
 
   (check-equal?
     (run 2 (q) (appendo `(1 2 3) `(4 5) q))
@@ -21,6 +32,40 @@
   (check-equal?
     (run 1 (q) (== (term-from-expression (make-list 5 "a")) q))
     '(("a" "a" "a" "a" "a")))
+
+  (test-equal?
+    "defrel permits multi-goal bodies, like faster-minikanren"
+	(run* (q) (rel/1-goal-body q))
+	'(cat))
+
+  (test-equal?
+    "proof we suspend when entering a defrel whose body has implicitly conjoined multiple goals in its body"
+	(run* (p q)
+	  (conde
+		((rel/2-goal-body p q))
+		((== p q))))
+	'((_.0 _.0) (fish horse)))
+
+  (test-equal?
+    "proof we do not suspend when entering a defrel whose body is a single goal"
+	(run* (q)
+	  (conde
+		((rel/1-goal-body q))
+		((== q 'zebra))))
+	'(cat zebra))
+
+  (test-equal?
+   (string-join
+	'("We must suspend when entering a defrel whose body is a single goal,"
+	  "in case that goal is immediately recurs without shrinking its argument like nevero"))
+   (let ([e (engine
+			 (lambda (e)
+			   (run 1 (q)
+				 (conde
+				   ((nevero q))
+				   ((== q 'zebra))))))])
+	 (and (engine-run 1000 e) (engine-result e)))
+	'(zebra))
 
   )
 


### PR DESCRIPTION
Adds support for multi-goal bodied defrels. 

Contains a broken test: @brysenPfingsten and I suspect that goals without fresh or conde, like nevero, need suspends, even though there is only one goal in the body of that defrel.

```
(defrel (nevero x)
    (nevero x))
```

`faster-minikanren` currently fails this same test.