### PR TITLE
Permit nullary relations and tests

### DIFF
--- a/private/spec.rkt
+++ b/private/spec.rkt
@@ -86,7 +86,7 @@
    (apply-relation e:racket-expr t:term ...)
    #;(project (x:term-variable ...) e:racket-expr ...)
 
-   (#%rel-app r:relation-name t:term ...+)
+   (#%rel-app r:relation-name t:term ...)
 
    (~> (r:id t ...)
        ;; TODO: this guard didn't work here, not sure why

--- a/tests/top-level.rkt
+++ b/tests/top-level.rkt
@@ -10,3 +10,28 @@
 (check-equal?
   (run 2 (q) (ones q))
   '(1 1))
+
+(defrel (bar x)
+  (== 'cat x))
+
+(defrel (call-bar)
+  (bar 'cat))
+
+(defrel (baz x)
+  (fresh (e1)
+    (== x `(,e1 fish))))
+
+(defrel (call-baz)
+  (fresh (x y)
+    (== x (list y))
+    (baz (list x y))))
+
+(test-equal?
+  "confirms that nullary relations can compile and run"
+  (run 1 (q) (call-bar))
+  '(_.0))
+
+(test-equal?
+  "confirms that nullary relations w/fresh can compile and run"
+  (run 1 (q) (call-baz))
+  '(_.0))


### PR DESCRIPTION
Simple one-line change in the syntax-spec to allow nullary relations. Tests confirm it works.