### PR TITLE
Static arity checks for relations

### DIFF
--- a/private/compile/generate-code.rkt
+++ b/private/compile/generate-code.rkt
@@ -6,6 +6,7 @@
                        (prefix-in mku: "../../mk/private-unstable.rkt")
                        "../forms.rkt"
                        "../runtime.rkt")
+         "../relation-arity.rkt"
          "prop-vars.rkt"
          "utils.rkt"
          syntax-spec-v2/private/ee-lib/main
@@ -17,15 +18,9 @@
          (only-in syntax/parse
                   (define/syntax-parse def/stx))
          syntax/stx
-         "../syntax-classes.rkt"
-         syntax-spec-v2)
+         "../syntax-classes.rkt")
 
-(provide generate-goal/entry generate-relation generate-term
-         relation-arity)
-
-
-
-(define-persistent-symbol-table relation-arity)
+(provide generate-goal/entry generate-relation generate-term)
 
 (define specialize-unify? (make-parameter #t))
 
@@ -74,15 +69,7 @@
      (def/stx c^ (free-id-table-ref constraint-impls #'c))
      (maybe-bind-surrounding-current-state-var stx #`(c^ #,(generate-term #'t1) #,(generate-term #'t2)))]
     [(#%rel-app n:id t ...)
-     (define actual (length (attribute t)))
-     (define expected (symbol-table-ref relation-arity #`n))
-     
-     (when (not (= actual expected ))
-       (raise-syntax-error
-        #f
-        (format "wrong number of arguments to relation; actual ~a, expected ~a" actual expected)
-        (compiled-from #'n)))
-     
+     (check-rel-app-arity #'n (attribute t))
      (maybe-bind-surrounding-current-state-var stx #`(n #,@ (stx-map generate-term #'(t ...))))]
     [(disj g ...)
      #`(mk:conde

--- a/private/interface-macros.rkt
+++ b/private/interface-macros.rkt
@@ -25,7 +25,8 @@
    racket/generic
    "compile.rkt"
    (only-in syntax/parse [define/syntax-parse def/stx])
-   "syntax-classes.rkt"))
+   "syntax-classes.rkt"
+   (only-in "../private/compile/generate-code.rkt" relation-arity)))
 
 (provide run run* defrel
          quote cons
@@ -85,7 +86,11 @@
   #:binding [(export name) (scope (bind x) g)]
 
   #:lhs
-  [#'name]
+  [(symbol-table-set!
+      relation-arity
+      #'name
+      (length (syntax->list #'(x ...))))
+     #'name]
   #:rhs
   [(symbol-table-set! expanded-relation-code
                       #'name

--- a/private/interface-macros.rkt
+++ b/private/interface-macros.rkt
@@ -26,7 +26,7 @@
    "compile.rkt"
    (only-in syntax/parse [define/syntax-parse def/stx])
    "syntax-classes.rkt"
-   (only-in "../private/compile/generate-code.rkt" relation-arity)))
+   "relation-arity.rkt"))
 
 (provide run run* defrel
          quote cons
@@ -86,11 +86,8 @@
   #:binding [(export name) (scope (bind x) g)]
 
   #:lhs
-  [(symbol-table-set!
-      relation-arity
-      #'name
-      (length (syntax->list #'(x ...))))
-     #'name]
+  [(record-relation-arity! #'name (attribute x))
+   #'name]
   #:rhs
   [(symbol-table-set! expanded-relation-code
                       #'name

--- a/private/relation-arity.rkt
+++ b/private/relation-arity.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+
+(provide record-relation-arity!
+         check-rel-app-arity)
+
+(require (for-template syntax-spec-v2)
+         (only-in syntax-spec-v2/private/ee-lib/main compiled-from))
+
+(define-persistent-symbol-table relation-arity)
+
+(define (record-relation-arity! name args)
+  (symbol-table-set! relation-arity name (length args)))
+
+(define (check-rel-app-arity name args)
+  (define actual (length args))
+  (define expected (symbol-table-ref relation-arity name))
+  
+  (when (not (= actual expected))
+    (raise-syntax-error
+     #f
+     (format "wrong number of arguments to relation; actual ~a, expected ~a" actual expected)
+     (compiled-from name))))

--- a/tests/arity-tests.rkt
+++ b/tests/arity-tests.rkt
@@ -17,55 +17,45 @@
                 (convert-compile-time-error
                  (run* (q r) (sameo q r)))))
 
-(define (read-all port)
-  (let loop ()
-    (let ([expr (read port)])
-      (if (eof-object? expr)
-          '()
-          (cons expr (loop))))))
-
-(define (check-static-error program-str) ;; Need this for defrels
-  (parameterize ([current-namespace (make-base-namespace)])
-    (expand
-     (datum->syntax
-      #f
-      `(module static-error-checker racket
-         (require "../main.rkt")
-         ,@(read-all (open-input-string program-str)))))))
+(define-syntax-rule 
+  (eval-mk-module defn-or-expr ...)
+  (eval #'(module eval-mk-module racket
+            (require "../main.rkt")
+            defn-or-expr ...)))
 
 (test-exn "Recursive relation call with wrong arity is a static error"
           #rx"wrong number of arguments to relation; actual 3, expected 2"
           (λ ()
-            (check-static-error 
-             "(defrel (bar x y)
+            (eval-mk-module 
+             (defrel (bar x y)
                (conde
-                [(== x y)]
-                [(fresh (a b c)
-                    (bar a b c))]))")))
+                 [(== x y)]
+                 [(fresh (a b c)
+                    (bar a b c))])))))
 
 (test-not-exn "Recursive relation call with correct arity is not a static error"
               (λ ()
-                (check-static-error 
-                 "(defrel (bar x y)
+                (eval-mk-module 
+                 (defrel (bar x y)
                    (conde
                      [(== x y)]
                      [(fresh (a b)
-                        (bar a b))]))")))
+                        (bar a b))])))))
 
 (test-exn "Mutual recursion with arity mismatch is a static error 1"
           #rx"wrong number of arguments to relation; actual 1, expected 2"
           (λ ()
-            (check-static-error 
-             "(defrel (foo x y)
-                (bar x))
-              (defrel (bar x y)
-                (foo y x))")))
+            (eval-mk-module 
+             (defrel (foo x y)
+               (bar x))
+             (defrel (bar x y)
+               (foo y x)))))
 
 (test-exn "Mutual recursion with arity mismatch is a static error 2"
           #rx"wrong number of arguments to relation; actual 1, expected 2"
           (λ ()
-            (check-static-error 
-             "(defrel (foo x y)
-                (bar x y))
-              (defrel (bar x y)
-                (foo y))")))
+            (eval-mk-module 
+             (defrel (foo x y)
+               (bar x y))
+             (defrel (bar x y)
+               (foo y)))))

--- a/tests/arity-tests.rkt
+++ b/tests/arity-tests.rkt
@@ -1,0 +1,71 @@
+#lang racket
+
+(require "../main.rkt"
+         (except-in rackunit fail)
+         syntax/macro-testing)
+
+(defrel (sameo x y) (== x y))
+
+(test-exn "Relation call with wrong arity is a static error"
+          #rx"wrong number of arguments to relation; actual 3, expected 2"
+          (λ ()
+            (convert-compile-time-error
+             (run* (q r s) (sameo q r s)))))
+
+(test-not-exn "Relation call with correct arity is not a static error"
+              (λ ()
+                (convert-compile-time-error
+                 (run* (q r) (sameo q r)))))
+
+(define (read-all port)
+  (let loop ()
+    (let ([expr (read port)])
+      (if (eof-object? expr)
+          '()
+          (cons expr (loop))))))
+
+(define (check-static-error program-str) ;; Need this for defrels
+  (parameterize ([current-namespace (make-base-namespace)])
+    (expand
+     (datum->syntax
+      #f
+      `(module static-error-checker racket
+         (require "../main.rkt")
+         ,@(read-all (open-input-string program-str)))))))
+
+(test-exn "Recursive relation call with wrong arity is a static error"
+          #rx"wrong number of arguments to relation; actual 3, expected 2"
+          (λ ()
+            (check-static-error 
+             "(defrel (bar x y)
+               (conde
+                [(== x y)]
+                [(fresh (a b c)
+                    (bar a b c))]))")))
+
+(test-not-exn "Recursive relation call with correct arity is not a static error"
+              (λ ()
+                (check-static-error 
+                 "(defrel (bar x y)
+                   (conde
+                     [(== x y)]
+                     [(fresh (a b)
+                        (bar a b))]))")))
+
+(test-exn "Mutual recursion with arity mismatch is a static error 1"
+          #rx"wrong number of arguments to relation; actual 1, expected 2"
+          (λ ()
+            (check-static-error 
+             "(defrel (foo x y)
+                (bar x))
+              (defrel (bar x y)
+                (foo y x))")))
+
+(test-exn "Mutual recursion with arity mismatch is a static error 2"
+          #rx"wrong number of arguments to relation; actual 1, expected 2"
+          (λ ()
+            (check-static-error 
+             "(defrel (foo x y)
+                (bar x y))
+              (defrel (bar x y)
+                (foo y))")))


### PR DESCRIPTION
Following the direction of [this](https://github.com/michaelballantyne/syntax-spec/blob/9c0481676c9005e1ab064cb46805590d167050c2/demos/mk-workshop-2024/compile-with-check.rkt) and [that](https://github.com/michaelballantyne/syntax-spec/blob/9c0481676c9005e1ab064cb46805590d167050c2/demos/mk-workshop-2024/compile-with-check.rkt).

Unit tests included.